### PR TITLE
Auto configure xulieta.xml with the plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,10 @@
         "codelicia/xulieta": "1.0.x-dev as 1.0.0",
         "doctrine/coding-standard": "^9.0.0",
         "phpunit/phpunit": "^9.4"
+    },
+    "extra": {
+        "xulieta": {
+            "validator": ["Codelicia\\XulietaJson\\JsonValidator"]
+        }
     }
 }


### PR DESCRIPTION
It is possible for a plugin, to auto-register himself once a composer
install/require operation is executed. For that, we need to add to the
plugin "composer.json" some extra configuration keys:

 - extra.xulieta.parser
 - extra.xulieta.validator