### PR TITLE
Remove support to PHP 8.0

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2']
+        php-versions: ['8.1', '8.2']
 
     steps:
       - name: Setup PHP

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Xulieta Plugin for JSON validation",
     "license": "MIT",
     "require": {
-        "php": "^8.0 || ^8.1 || ^8.2"
+        "php": "^8.1 || ^8.2"
     },
     "require-dev": {
         "codelicia/xulieta": "^1.0.0",


### PR DESCRIPTION
PHP 8.0 is currently on Security Support only.
It means the current released version of
xulieta-json still works on 8.0 but new
development will be done on stable versions
and with active support of PHP.